### PR TITLE
Use Tox and setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /.cache
 .coverage
+*.pyc
+/*.egg-info
+/.eggs/
+/.tox/

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,3 @@
 machine:
   python:
     version: 2.7.6
-
-dependencies:
-  override:
-    - make install
-
-test:
-  override:
-    - make test

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,44 @@
+from setuptools import setup
+from setuptools.command.test import test as TestCommand
+import sys
+
+
+class Tox(TestCommand):
+    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.tox_args = None
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import tox
+        import shlex
+        args = self.tox_args
+        if args:
+            args = shlex.split(self.tox_args)
+        errno = tox.cmdline(args=args)
+        sys.exit(errno)
+
+
+setup(
+    name='tagcompare',
+    description='Easily and simply launch services into AWS',
+    url='https://github.com/paperg/tagcompare',
+    packages=['tagcompare', 'tagcompare.test'],
+    install_requires=[
+        'selenium',
+        'requests',
+        'pillow',
+    ],
+    package_data={
+        '': ['*.json'],
+    },
+    tests_require=['tox'],
+    cmdclass={'test': Tox},
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27
+
+[testenv]
+commands = py.test --cov tagcompare --cov-config .coveragerc --cov=tagcompare tagcompare/test/
+deps =
+    pytest
+    pytest-cov


### PR DESCRIPTION
This is a more conventional interface for Python projects than `make`.
It allows the package to be installed with `pip`, and things like
`python setup.py test` are conventionally expected (so we don't need to
make an exception to the CircleCI configuration).

Running the tests in Tox isolates the test environment from the python
environment on the workstation. It would also be easy to edit tox.ini
and run the tests with Python 3, if that were a goal.
