### PR TITLE
Support comparing builds with tagcompare

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-omit = tagcompare/test/*,tagcompare/main.py
+omit = tagcompare/test/*,tagcompare/main.py,tagtester/*
 
 [report]
 exclude_lines =

--- a/setup.py
+++ b/setup.py
@@ -46,14 +46,16 @@ if __name__ == '__main__':
         version=git_version(),
         description='Capture and compare creative tags!',
         url='https://github.com/paperg/tagcompare',
-        packages=['tagcompare', 'tagcompare.test'],
+        packages=['tagcompare', 'tagcompare.test', 'tagtester'],
         entry_points={
             'console_scripts': [
                 'tagcapture = tagcompare.capture:main',
                 'tagcompare = tagcompare.main:main',
+                'tagtester = tagtester.main:main'
             ]
         },
         install_requires=[
+            'virtualenv',
             'selenium',
             'requests',
             'pillow',

--- a/tagcompare/compare.py
+++ b/tagcompare/compare.py
@@ -53,7 +53,6 @@ def __write_result_image(pathbuilder, result_image,
 
 
 def _get_compare_matrix(pathbuilder, configs):
-    compare_image = None
     compare_pb = pathbuilder.clone(build=output.DEFAULT_BUILD_NAME)
 
     # Assumes all compared images will have the same dimensions, also that there is at

--- a/tagcompare/webdriver.py
+++ b/tagcompare/webdriver.py
@@ -1,7 +1,6 @@
 import time
 
 from selenium.common.exceptions import WebDriverException
-
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
@@ -18,6 +17,20 @@ def setup_webdriver(capabilities):
     driver = __setup_remote_webdriver(capabilities=capabilities)
     driver.implicitly_wait(20)
     return driver
+
+
+def get_capabilities_for_config(config_name, build, max_duration=3600,
+                                all_configs=None):
+    if not all_configs:
+        all_configs = settings.DEFAULT.all_configs
+    assert config_name in all_configs, 'configname not in all_configs!'
+    config_data = all_configs[config_name]
+    assert config_data['enabled'], 'config not enabled!'
+    capabilities = config_data['capabilities']
+    capabilities['name'] = config_name
+    capabilities['build'] = build
+    capabilities['maxDuration'] = max_duration
+    return capabilities
 
 
 def __setup_remote_webdriver(capabilities):

--- a/tagtester/main.py
+++ b/tagtester/main.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+
+import argparse
+import logging
+import os
+
+from tagcompare import placelocal
+from tagcompare import webdriver
+from tagcompare import output
+from tagcompare import settings
+from tagcompare import capture
+from tagcompare import image
+
+
+MODULE_NAME = 'tagtester'
+OUTPUT_BASEDIR = os.path.join(settings.HOME_DIR, MODULE_NAME)
+SETTINGS = {
+    'domain': 'www.placelocalqa.com',
+    'cids': [148487, 148485, 147966, 147878, 147871, 147870, 147869, 147868,
+             147867, 147866, 147865, 147862],
+    'sizes': ['medium_rectangle', 'skyscraper', 'halfpage'],
+    'types': ['iframe'],
+    'configs': ['chrome', 'firefox']
+}
+
+
+def capture_tags():
+    logging.info(
+        'Starting tagtester capture with settings: {}'.format(SETTINGS))
+    test_domain = SETTINGS['domain']
+    test_cids = SETTINGS['cids']
+    test_sizes = SETTINGS['sizes']
+    test_types = SETTINGS['types']
+    test_configs = SETTINGS['configs']
+
+    build = output.generate_build_string(prefix='tagtester')
+    pb = output.create(build, basepath=OUTPUT_BASEDIR)
+
+    browser_errors = {}
+    tag_count = 0
+    for config in test_configs:
+        test_caps = webdriver.get_capabilities_for_config(config_name=config,
+                                                          build=build)
+        tags = placelocal.get_tags_for_campaigns(
+            cids=test_cids, domain=test_domain)
+        driver = webdriver.setup_webdriver(capabilities=test_caps)
+
+        for cid in test_cids:
+            for s in test_sizes:
+                for t in test_types:
+                    tag_count += 1
+                    pb.cid = cid
+                    pb.tagsize = s
+                    pb.tagtype = t
+                    pb.config = config
+                    taghtml = tags[cid][s][t]
+                    pb.create()
+                    browser_errors[pb.tagname] = capture.capture_tag(
+                        driver=driver, tag_html=taghtml,
+                        output_path=pb.tagimage, tagtype=t)
+
+    if browser_errors:
+        logging.error('Found browser errors in {} tags:\n{}'.format(
+            len(browser_errors), browser_errors))
+    else:
+        logging.info('Completed capture of {} tags'.format(tag_count))
+    return build
+
+
+def compare_builds(build, reference='golden'):
+    """
+    Compares a build against a reference build, (by default named 'golden' build)
+    :param buildname:
+    :param golden:
+    :return:
+    """
+    compare_build = build + "_vs_" + reference
+    logging.info('Starting compare build: %s', compare_build)
+
+    # Compare all the tag images in the build path against the golden set
+    build_paths = output.get_all_paths(buildname=build, basedir=OUTPUT_BASEDIR)
+    compare_errors = {}
+
+    for bp in build_paths:
+        build_pb = output.create_from_path(bp, basepath=OUTPUT_BASEDIR)
+        ref_pb = build_pb.clone(build=reference)
+
+        # We can compare iff both paths exists
+        build_image = build_pb.tagimage
+        ref_image = ref_pb.tagimage
+        if not os.path.exists(build_image):
+            logging.warn('SKIPPING compare: path does not exist at {}'.format(
+                build_pb.path))
+            continue
+        if not os.path.exists(ref_image):
+            logging.warn('SKIPPING compare: path does not exist at {}'.format(
+                ref_pb.path))
+            # TODO: In this case we want to have the option of making new ref
+            continue
+
+        result = image.compare(build_pb.tagimage, ref_pb.tagimage)
+        logging.debug('Result for %s: %s', compare_build, result)
+        if result > settings.ImageErrorLevel.SLIGHT:
+            compare_errors[build_image] = result
+            logging.warn('Invalid compare result for %s', build_image)
+
+    logging.info('Finished compare build %s for %s images!  Found %s errors:\n%s',
+                 compare_build, len(build_paths), len(compare_errors), compare_errors)
+    return True
+
+
+def __parse_params_to_settings():
+    """
+    Handles parsing commandline args and set appropriate settings from them
+    :return: the key/value pair for the commandline args parsed
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-b', '--compare-build',
+                        default=None,
+                        help='Specify a build name to compare with the reference set')
+
+    parser.add_argument('--verbose', action='store_true', default=False,
+                        help='Enable verbose logging for debugging')
+    args = parser.parse_args()
+    logging.debug("tagtester params: %s", args)
+    return args
+
+
+def main():
+    args = __parse_params_to_settings()
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    if not args.compare_build:
+        build = capture_tags()
+    else:
+        build = args.compare_build
+
+    compare_builds(build)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
New package `tagtester` uses tagcompare to run tests against a set of predefined cids/env

This is only the rudimentary implementation which captures a set of images in a build
then compares against a reference build.

TODO:
- Generate compare images on error
- Automatically make reference images if it doesn't exist
- Tests
- Documentation

Initial implementation for https://github.com/paperg/tagcompare/issues/45
